### PR TITLE
feat: 클라이언트 컴포넌트에서 revalidatePath 호출

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,35 @@
+// app/api/revalidate/route.ts
+
+import { NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function POST(request: Request) {
+  const authHeader = request.headers.get('Authorization');
+
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Authorization header missing' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { path } = await request.json();
+
+  try {
+    // Revalidate the specified path
+    console.log('path? ', path);
+    revalidatePath(path);
+    return NextResponse.json({ revalidated: true, now: Date.now() });
+  } catch (err) {
+    // Check if 'err' is an instance of Error
+    if (err instanceof Error) {
+      return NextResponse.json({ revalidated: false, error: err.message }, { status: 500 });
+    } else {
+      // Handle unknown error types gracefully
+      return NextResponse.json(
+        { revalidated: false, error: 'An unknown error occurred' },
+        { status: 500 }
+      );
+    }
+  }
+}

--- a/app/app/(users)/account-status/account-status-client.tsx
+++ b/app/app/(users)/account-status/account-status-client.tsx
@@ -182,8 +182,35 @@ export default function AccountStatusClient({
     [setupSSEConnection, stopSSEConnection]
   );
 
-  const closeModal = () => {
+  const closeModal = async () => {
     setIsModalOpen(false);
+
+    // 모달이 닫힐때마다 해당 페이지 캐시 revalidate
+    await revalidateCurrentPath();
+  };
+
+  const revalidateCurrentPath = async () => {
+    console.log('revalidateCurrentPath');
+
+    const { credentials } = getUserAuth();
+
+    try {
+      const response = await fetch('/api/revalidate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${credentials}`,
+        },
+        body: JSON.stringify({ path: '/app/account-status' }),
+      });
+      if (response.ok) {
+        console.log('Path revalidated successfully');
+      } else {
+        console.error('Failed to revalidate path');
+      }
+    } catch (error) {
+      console.error('Error revalidating path:', error);
+    }
   };
 
   return (


### PR DESCRIPTION
- 클라이언트 컴포넌트에서 revalidatePath('...')를 바로 호출할 수 없으므로 (호출은 할 수 있으나 동작하지 않음) api route handler를 활용해서 api 호출하듯이 revalidatePath 호출 시도
- 커리어 계정 관리 페이지에서 모달이 닫힐때마다 페이지 캐시를 제거하여 새로고침 효과를 주기 위함