### PR TITLE
Hotfix: fix: url 유효성 검사식 수정

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -45,7 +45,7 @@ export function validatePhoneNumber(phoneNumber: string) {
 }
 
 // 기본적인 URL 유효성 검사를 위한 정규 표현식
-const URL_REGEX = /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/;
+const URL_REGEX = /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w\p{L}\p{N}%\-._~]*)*\/?$/iu;
 
 export const validateUrl = (url: string): string | null => {
   if (!url) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- 링크에 유니코드가 들어가는 경우 대응 (ex. https://www.example.com/%A0%95-6594b2176/)