### PR TITLE
hotfix: highlight option to record special logs only

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           urlBlocklist: [],
         }}
         excludedHostnames={['localhost']} // skip localhost tracking
+        consoleMethodsToRecord={['warn', 'error']}
         debug
       />
       <html lang="en">


### PR DESCRIPTION
- 모니터링 툴 highlight 툴은 로그를 모두 기록하는 것이 디폴트. 
- warn 이나 error만 기록하도록 옵션 추가